### PR TITLE
Add Gentoo support to the installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -302,6 +302,8 @@ get_distro_family() {
 			echo "fedora"
 		elif [ "${ID:-}" = "arch" ] || [[ "${ID_LIKE:-}" =~ arch ]]; then
 			echo "arch"
+		elif [ "${ID:-}" = "gentoo" ] || [[ "${ID_LIKE:-}" =~ gentoo ]]; then
+			echo "gentoo"
 		elif [[ "${ID:-}" =~ opensuse ]] || [[ "${ID_LIKE:-}" =~ opensuse ]]; then
 			echo "opensuse"
 		else
@@ -738,6 +740,7 @@ suggest_native_steam_install() {
 		debian)   echo "sudo apt update && sudo apt install steam-installer" ;;
 		fedora)   echo "sudo dnf install steam" ;;
 		arch)     echo "sudo pacman -S steam" ;;
+		gentoo)   echo "sudo eselect repository enable steam-overlay && sudo emaint sync -r steam-overlay && sudo emerge --ask games-util/steam-launcher" ;;
 		opensuse) echo "sudo zypper install steam" ;;
 		*)        echo "$(L "see your distro's documentation to install native Steam" \
 		                    "consulte a documentação da sua distro para instalar a Steam nativa")" ;;
@@ -942,13 +945,13 @@ pkg_for() {
 	local tool="$1" family="$2"
 	case "$tool" in
 		jq)
-			echo "jq" ;;
+			if [ "$family" = "gentoo" ]; then echo "app-misc/jq"; else echo "jq"; fi ;;
 		curl)
-			echo "curl" ;;
+			if [ "$family" = "gentoo" ]; then echo "net-misc/curl"; else echo "curl"; fi ;;
 		tar)
-			echo "tar" ;;
+			if [ "$family" = "gentoo" ]; then echo "app-arch/tar"; else echo "tar"; fi ;;
 		unzip)
-			echo "unzip" ;;
+			if [ "$family" = "gentoo" ]; then echo "app-arch/unzip"; else echo "unzip"; fi ;;
 		steam-run)
 			echo "steam-run" ;;
 		notify-send)
@@ -959,6 +962,7 @@ pkg_for() {
 				debian)   echo "libnotify-bin" ;;
 				fedora)   echo "libnotify" ;;
 				arch)     echo "libnotify" ;;
+				gentoo)   echo "x11-libs/libnotify" ;;
 				opensuse) echo "libnotify-tools" ;;
 				*)        echo "libnotify" ;;
 			esac
@@ -981,6 +985,9 @@ pm_install() {
 			;;
 		arch)
 			$sudo_cmd pacman -S --noconfirm "$@"
+			;;
+		gentoo)
+			$sudo_cmd emerge --ask=n --noreplace "$@"
 			;;
 		opensuse)
 			$sudo_cmd zypper install -y "$@"

--- a/scripts/test-distro-detect.sh
+++ b/scripts/test-distro-detect.sh
@@ -75,6 +75,10 @@ fixture 'ID=arch'
 if is_immutable_distro; then r=1; else r=0; fi
 check "immutable: arch -> no" "$r"
 
+fixture 'ID=gentoo'
+if is_immutable_distro; then r=1; else r=0; fi
+check "immutable: gentoo -> no (mutable, Portage-driven)" "$r"
+
 # --- get_distro_family (unchanged behaviour across the refactor) ------------
 
 fixture 'ID=bazzite
@@ -88,6 +92,13 @@ ID_LIKE="arch"'
 fixture 'ID=linuxmint
 ID_LIKE="ubuntu debian"'
 [ "$(get_distro_family)" = "debian" ]; check "family: mint -> debian" $?
+
+fixture 'ID=gentoo'
+[ "$(get_distro_family)" = "gentoo" ]; check "family: gentoo -> gentoo" $?
+
+fixture 'ID=funtoo
+ID_LIKE="gentoo"'
+[ "$(get_distro_family)" = "gentoo" ]; check "family: funtoo (ID_LIKE=gentoo) -> gentoo" $?
 
 # --- NixOS ------------------------------------------------------------------
 # NixOS has no /usr/bin, no system package manager the installer can drive,
@@ -239,6 +250,18 @@ rm -rf "$EMPTYBIN"
 [ "$(nixos_pkg_for tar)" = "gnutar" ]; check "nixos_pkg_for: tar -> gnutar" $?
 [ "$(nixos_pkg_for notify-send)" = "libnotify" ]; check "nixos_pkg_for: notify-send -> libnotify" $?
 [ "$(nixos_pkg_for jq)" = "jq" ]; check "nixos_pkg_for: jq -> jq (unchanged)" $?
+
+# pkg_for on Gentoo resolves full Portage atoms (category required by emerge
+# when scripted); every other family keeps the plain upstream names.
+[ "$(pkg_for jq gentoo)" = "app-misc/jq" ]; check "pkg_for: jq @ gentoo -> app-misc/jq" $?
+[ "$(pkg_for curl gentoo)" = "net-misc/curl" ]; check "pkg_for: curl @ gentoo -> net-misc/curl" $?
+[ "$(pkg_for tar gentoo)" = "app-arch/tar" ]; check "pkg_for: tar @ gentoo -> app-arch/tar" $?
+[ "$(pkg_for unzip gentoo)" = "app-arch/unzip" ]; check "pkg_for: unzip @ gentoo -> app-arch/unzip" $?
+[ "$(pkg_for notify-send gentoo)" = "x11-libs/libnotify" ]; check "pkg_for: notify-send @ gentoo -> x11-libs/libnotify" $?
+[ "$(pkg_for jq debian)" = "jq" ]; check "pkg_for: jq @ debian -> jq (unchanged)" $?
+[ "$(pkg_for unzip fedora)" = "unzip" ]; check "pkg_for: unzip @ fedora -> unzip (unchanged)" $?
+[ "$(pkg_for notify-send opensuse)" = "libnotify-tools" ]; check "pkg_for: notify-send @ opensuse unchanged" $?
+[ "$(pkg_for notify-send debian)" = "libnotify-bin" ]; check "pkg_for: notify-send @ debian unchanged" $?
 
 rm -rf "$TESTDIR"
 echo ""


### PR DESCRIPTION
# Add Gentoo support to the installer

## Summary

Teaches the installer's distro layer about Gentoo (and Funtoo via
`ID_LIKE=gentoo`), which currently falls into the `unknown` family and aborts
with "Unknown distro" when dependencies are missing.

## Changes

**install.sh**

- `get_distro_family()`: new `gentoo` family (`ID=gentoo` or `ID_LIKE`
  containing `gentoo`).
- `pkg_for()`: full Portage atoms for Gentoo — `app-misc/jq`,
  `net-misc/curl`, `app-arch/tar`, `app-arch/unzip`,
  `x11-libs/libnotify`. All other families keep the plain names.
- `pm_install()`: gentoo branch runs `emerge --ask=n --noreplace <pkgs>`.
- `suggest_native_steam_install()`: points at the steam-overlay flow —
  `games-util/steam-launcher` is not in the main tree, so the hint enables
  the overlay, syncs it, then emerges the launcher (per the Gentoo Wiki).

**scripts/test-distro-detect.sh**

- Fixtures: `ID=gentoo` -> family `gentoo`, immutable -> no;
  `ID=funtoo ID_LIKE="gentoo"` -> family `gentoo`.
- `pkg_for` pins for all five tools on Gentoo plus regression checks that
  debian/fedora/opensuse mappings are unchanged.

## Notes

- Gentoo is treated as mutable: Portage drives dependency installs exactly
  like apt/dnf/pacman/zypper on the other families. No interaction with the
  immutable-OS paths.
- The only automated installs are the five small CLI tools; Steam itself is
  never installed by the script on any distro — on Gentoo the printed hint
  covers the overlay + license setup (`ValveSteamLicense`) that Portage
  requires.

## Testing

- `bash scripts/test-distro-detect.sh` — 46/46 checks pass (13 new).
- `bash -n install.sh` clean.
- Dry-run of `pm_install gentoo ...` with a stubbed `emerge` produces
  `emerge --ask=n --noreplace app-misc/jq net-misc/curl x11-libs/libnotify`.
