### PR TITLE
Millennium cleanup opt out. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2614,9 +2614,8 @@ $(L "Options" "Opções"):
                   "Instala apenas o slsteam-moon + Lumen (pula o plugin LuaTools).")
   --nolaunch   $(L "Do not auto-start Steam at the end of install." \
                   "Não inicia a Steam automaticamente ao final da instalação.")
-# TODO: BR translation 
   --keep-millennium $(L "Do not remove millennium's config/data (Old luatools plugin is still removed)." \
-                  "Do not remove millennium's config/data (Old luatools plugin is still removed).")
+                  "Não remover os dados/configurações do Millennium (o plugin luatools antigo ainda será removido).")
   --slsteam-channel stable|beta
                $(L "Select the slsteam-moon update channel (default: stable)." \
                   "Seleciona o canal de atualização do slsteam-moon (padrão: stable).")

--- a/install.sh
+++ b/install.sh
@@ -2662,14 +2662,14 @@ do_autolaunch() {
 # channel, records the first invalid argument in OPT_BAD_ARG and returns 1.
 # Resets its output vars each call so it's safe to invoke repeatedly.
 parse_args() {
-	OPT_NOPLUGIN=0
-	OPT_NOLAUNCH=0
-	OPT_KEEP_MILLENNIUM=0
-	OPT_HELP=0
+	OPT_NOPLUGIN=${LUATOOLS_MOON_NOPLUGIN:-0}
+	OPT_NOLAUNCH=${LUATOOLS_MOON_NOLAUNCH:-0}
+	OPT_KEEP_MILLENNIUM=${LUATOOLS_MOON_KEEP_MILLENNIUM:-0}
+	OPT_HELP=${LUATOOLS_MOON_HELP:-0}
+	OPT_SLS_CHANNEL="${LUATOOLS_MOON_SLS_CHANNEL:-stable}"
+	OPT_PLUGIN_CHANNEL="${LUATOOLS_MOON_PLUGIN_CHANNEL:-stable}"
+	OPT_LUMEN_CHANNEL="${LUATOOLS_MOON_LUMEN_CHANNEL:-stable}"
 	OPT_BAD_ARG=""
-	OPT_SLS_CHANNEL="stable"
-	OPT_PLUGIN_CHANNEL="stable"
-	OPT_LUMEN_CHANNEL="stable"
 	while [ "$#" -gt 0 ]; do
 		case "$1" in
 			--noplugin) OPT_NOPLUGIN=1 ;;

--- a/install.sh
+++ b/install.sh
@@ -1443,7 +1443,11 @@ cleanup_previous_install() {
 	# CLOSED — and Lumen attaches via that port. So a pre-existing Millennium
 	# install would BLOCK Lumen. Remove the whole framework here (not just the
 	# old plugin dir handled above) so 8080 is free for Lumen.
-	remove_millennium_framework
+	# Keep it as user's request if arguement --keep-millennium is passed. 
+	if [ "${OPT_KEEP_MILLENNIUM:-0}" != 1 ]; then
+		remove_millennium_framework
+	fi
+	
 
 	log_success "$(L "Previous installation cleaned up" "Instalação anterior limpa")"
 }
@@ -2610,6 +2614,9 @@ $(L "Options" "Opções"):
                   "Instala apenas o slsteam-moon + Lumen (pula o plugin LuaTools).")
   --nolaunch   $(L "Do not auto-start Steam at the end of install." \
                   "Não inicia a Steam automaticamente ao final da instalação.")
+# TODO: BR translation 
+  --keep-millennium $(L "Do not remove millennium's config/data (Old luatools plugin is still removed)." \
+                  "Do not remove millennium's config/data (Old luatools plugin is still removed).")
   --slsteam-channel stable|beta
                $(L "Select the slsteam-moon update channel (default: stable)." \
                   "Seleciona o canal de atualização do slsteam-moon (padrão: stable).")
@@ -2657,6 +2664,7 @@ do_autolaunch() {
 parse_args() {
 	OPT_NOPLUGIN=0
 	OPT_NOLAUNCH=0
+	OPT_KEEP_MILLENNIUM=0
 	OPT_HELP=0
 	OPT_BAD_ARG=""
 	OPT_SLS_CHANNEL="stable"
@@ -2666,6 +2674,7 @@ parse_args() {
 		case "$1" in
 			--noplugin) OPT_NOPLUGIN=1 ;;
 			--nolaunch) OPT_NOLAUNCH=1 ;;
+			--keep-millennium) OPT_KEEP_MILLENNIUM=1 ;;
 			--slsteam-channel|--plugin-channel|--lumen-channel)
 				local option="$1"
 				if [ "$#" -lt 2 ]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1696,10 +1696,12 @@ main() {
 	uninstall_luatools_plugin
 
 	print_section "$(L "Removing Lumen" "Removendo Lumen")"
-	uninstall_lumen
-
+	uninstall_lumen    
+	
+	if [ -z "${OPT_KEEP_MILLENNIUM:-}" ]; then
 	print_section "$(L "Removing Millennium" "Removendo Millennium")"
 	uninstall_millennium
+    fi	
 
 	print_section "$(L "Removing slsteam-moon" "Removendo slsteam-moon")"
 	uninstall_slsteam_moon

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1698,7 +1698,7 @@ main() {
 	print_section "$(L "Removing Lumen" "Removendo Lumen")"
 	uninstall_lumen    
 	
-	if [ -z "${OPT_KEEP_MILLENNIUM:-}" ]; then
+	if [ -z "${LUATOOLS_MOON_KEEP_MILLENNIUM:-}" ]; then
 	print_section "$(L "Removing Millennium" "Removendo Millennium")"
 	uninstall_millennium
     fi	


### PR DESCRIPTION
- Added launch flag `--keep-millennium` to skip the millennium cleanup.
- Added environment variable based launch flags i.e.
  - `LUATOOLS_MOON_NOPLUGIN` can be set to `1` instead of passing `--noplugin`
  - `LUATOOLS_MOON_NOLAUNCH` can be set to `1` instead of passing `--nolaunch`
  - `LUATOOLS_MOON_KEEP_MILLENNIUM` can be set to `1` instead of passing `--keep-millennium`
  - `LUATOOLS_MOON_HELP` can be set to `1` instead of passing `--help` (No real use case but just for consistency)
  - `LUATOOLS_MOON_SLS_CHANNEL` can be set to `stable`/`beta` instead of passing via launch args. 
  - `LUATOOLS_MOON_PLUGIN_CHANNEL` can be set to `stable`/`beta` instead of passing via launch args. 
  - `LUATOOLS_MOON_LUMEN_CHANNEL` can be set to `stable`/`beta` instead of passing via launch args. 
  
  